### PR TITLE
Add empty RAG module skeletons

### DIFF
--- a/backend/src/rag/__init__.py
+++ b/backend/src/rag/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Initialize the retrieval-augmented generation package."""
+
+pass

--- a/backend/src/rag/document_processor.py
+++ b/backend/src/rag/document_processor.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Process documents before indexing in the vector store."""
+
+pass

--- a/backend/src/rag/embeddings.py
+++ b/backend/src/rag/embeddings.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Create and handle embeddings for documents."""
+
+pass

--- a/backend/src/rag/rag_graph.py
+++ b/backend/src/rag/rag_graph.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Define the RAG graph for orchestrating retrieval and generation."""
+
+pass

--- a/backend/src/rag/retriever.py
+++ b/backend/src/rag/retriever.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Retrieve relevant documents from the vector store."""
+
+pass

--- a/backend/src/rag/vector_store.py
+++ b/backend/src/rag/vector_store.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+"""Manage the vector store for document embeddings."""
+
+pass


### PR DESCRIPTION
## Summary
- scaffold `rag` backend package for later development

## Testing
- `make lint_diff` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68522b15b93c832d9508e2b4f1e6b0f4