### PR TITLE
Add optional RAG workflow with unit test

### DIFF
--- a/backend/src/agent/rag_graph.py
+++ b/backend/src/agent/rag_graph.py
@@ -1,0 +1,23 @@
+"""Minimal RAG sub-graph."""
+from __future__ import annotations
+
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph import END, START, StateGraph
+
+from .state import OverallState
+
+
+def retrieve_documents(state: OverallState, config: RunnableConfig) -> OverallState:
+    """Return an empty answer string."""
+    return {"messages": [AIMessage(content="")]}  # pragma: no cover
+
+
+
+def create_rag_graph():
+    """Return a minimal RAG sub-graph."""
+    builder = StateGraph(OverallState)
+    builder.add_node("retrieve_documents", retrieve_documents)
+    builder.add_edge(START, "retrieve_documents")
+    builder.add_edge("retrieve_documents", END)
+    return builder.compile(name="rag-sub-graph")

--- a/backend/src/agent/state.py
+++ b/backend/src/agent/state.py
@@ -1,5 +1,7 @@
+"""Shared state definitions for the agent graphs."""
 from __future__ import annotations
 
+import operator
 from dataclasses import dataclass, field
 from typing import TypedDict
 
@@ -7,12 +9,8 @@ from langgraph.graph import add_messages
 from typing_extensions import Annotated
 
 
-import operator
-from dataclasses import dataclass, field
-from typing_extensions import Annotated
-
-
 class OverallState(TypedDict):
+    """State shared across the whole agent run."""
     messages: Annotated[list, add_messages]
     search_query: Annotated[list, operator.add]
     web_research_result: Annotated[list, operator.add]
@@ -21,9 +19,11 @@ class OverallState(TypedDict):
     max_research_loops: int
     research_loop_count: int
     reasoning_model: str
+    use_documents: bool
 
 
 class ReflectionState(TypedDict):
+    """State produced by the reflection step."""
     is_sufficient: bool
     knowledge_gap: str
     follow_up_queries: Annotated[list, operator.add]
@@ -32,19 +32,23 @@ class ReflectionState(TypedDict):
 
 
 class Query(TypedDict):
+    """Represents a single search query."""
     query: str
     rationale: str
 
 
 class QueryGenerationState(TypedDict):
+    """State containing generated queries."""
     query_list: list[Query]
 
 
 class WebSearchState(TypedDict):
+    """State for a single web search."""
     search_query: str
     id: str
 
 
 @dataclass(kw_only=True)
 class SearchStateOutput:
+    """Output after the full search cycle."""
     running_summary: str = field(default=None)  # Final report

--- a/backend/tests/unit_tests/test_rag_route.py
+++ b/backend/tests/unit_tests/test_rag_route.py
@@ -1,0 +1,23 @@
+import os
+
+from langchain_core.messages import HumanMessage
+
+os.environ.setdefault("GEMINI_API_KEY", "dummy")
+from agent import graph
+
+
+def test_use_documents_routs_to_rag():
+    state = {
+        "messages": [HumanMessage(content="test")],
+        "search_query": [],
+        "web_research_result": [],
+        "sources_gathered": [],
+        "initial_search_query_count": 0,
+        "max_research_loops": 0,
+        "research_loop_count": 0,
+        "reasoning_model": "",
+        "use_documents": True,
+    }
+
+    result = graph.invoke(state)
+    assert result["messages"][-1].content == ""


### PR DESCRIPTION
## Summary
- define OverallState `use_documents`
- create `rag_graph` with `retrieve_documents`
- route to the RAG sub-graph when `use_documents` is true
- verify routing with a unit test

## Testing
- `ruff check backend/src/agent/rag_graph.py backend/src/agent/graph.py backend/src/agent/state.py backend/tests/unit_tests/test_rag_route.py`
- `mypy backend/src/agent/rag_graph.py backend/src/agent/graph.py backend/src/agent/state.py backend/tests/unit_tests/test_rag_route.py` *(fails: many type errors)*
- `PYTHONPATH=backend/src GEMINI_API_KEY=dummy pytest backend/tests/unit_tests/test_rag_route.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6852350da9f8832db96cc63f593b94f3